### PR TITLE
add patch for beta.5 and detail usage in readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,28 @@ git apply ../base-export/alpha.22-import.patch
 cargo build --release --features=optimism --bin=op-reth
 ```
 
+A patch for reth beta.5 is also available via:
+
+```shell
+## in the reth repo, assuming you've made it a sibling to base-export/
+git checkout v0.2.0-beta.5
+git apply ../base-export/beta.5-import.patch
+
+cargo build --release --features=optimism --bin=op-reth
+```
+
 To import into a fresh `op-reth` this is how I did it (you'll need to clone `reth` and build `op-reth`)
 
 ```shell
 ## import.sh (in your reth directory, compiled as op-reth)
+## change datadir and adjust block number as needed
 set -e
 set -x
 for ((i=1; i<=13200000; i+=100000)); do
     start=$i
     end=$((i + 99999))
     echo "Importing" $start " - " $end
-    ./target/release/op-reth import --chain base ../base-export/data/blocks_$end
+    ./target/release/op-reth import --chain base --datadir <your_specified_data_dir> ../base-export/data/blocks_$end
 done
 ```
 

--- a/beta.5-import.patch
+++ b/beta.5-import.patch
@@ -1,0 +1,100 @@
+diff --git a/bin/reth/src/commands/import.rs b/bin/reth/src/commands/import.rs
+index f59e9e149..5ef8273a7 100644
+--- a/bin/reth/src/commands/import.rs
++++ b/bin/reth/src/commands/import.rs
+@@ -20,7 +20,10 @@ use reth_downloaders::{
+ };
+ use reth_interfaces::consensus::Consensus;
+ use reth_node_core::{events::node::NodeEvent, init::init_genesis};
++#[cfg(not(feature = "optimism"))]
+ use reth_node_ethereum::EthEvmConfig;
++#[cfg(feature = "optimism")]
++use reth_node_optimism::OptimismEvmConfig;
+ use reth_primitives::{stage::StageId, ChainSpec, PruneModes, B256};
+ use reth_provider::{HeaderSyncMode, ProviderFactory, StageCheckpointReader};
+ use reth_stages::{
+@@ -172,9 +175,14 @@ impl ImportCommand {
+             .into_task();
+ 
+         let (tip_tx, tip_rx) = watch::channel(B256::ZERO);
++        #[cfg(not(feature = "optimism"))]
+         let factory =
+             reth_revm::EvmProcessorFactory::new(self.chain.clone(), EthEvmConfig::default());
+ 
++        #[cfg(feature = "optimism")]
++        let factory =
++            reth_revm::EvmProcessorFactory::new(self.chain.clone(), OptimismEvmConfig::default());
++
+         let max_block = file_client.max_block().unwrap_or(0);
+ 
+         let mut pipeline = Pipeline::builder()
+diff --git a/crates/net/downloaders/src/file_client.rs b/crates/net/downloaders/src/file_client.rs
+index ebc5fe408..dc495eb6c 100644
+--- a/crates/net/downloaders/src/file_client.rs
++++ b/crates/net/downloaders/src/file_client.rs
+@@ -38,6 +38,9 @@ pub struct FileClient {
+ 
+     /// The buffered bodies retrieved when fetching new headers.
+     bodies: HashMap<BlockHash, BlockBody>,
++
++    /// Chain tip set based on highest incremental block hash
++    tip: Option<B256>,
+ }
+ 
+ /// An error that can occur when constructing and using a [`FileClient`].
+@@ -72,6 +75,8 @@ impl FileClient {
+         let mut headers = HashMap::new();
+         let mut hash_to_number = HashMap::new();
+         let mut bodies = HashMap::new();
++        let mut max_bock = 0u64;
++        let mut tip = None;
+ 
+         // use with_capacity to make sure the internal buffer contains the entire file
+         let mut stream = FramedRead::with_capacity(&reader[..], BlockFileCodec, file_len as usize);
+@@ -80,6 +85,11 @@ impl FileClient {
+             let block = block_res?;
+             let block_hash = block.header.hash_slow();
+ 
++            if block.number > max_bock {
++                max_bock = block.number;
++                tip = Some(block_hash);
++            }
++
+             // add to the internal maps
+             headers.insert(block.header.number, block.header.clone());
+             hash_to_number.insert(block_hash, block.header.number);
+@@ -95,12 +105,12 @@ impl FileClient {
+ 
+         trace!(blocks = headers.len(), "Initialized file client");
+ 
+-        Ok(Self { headers, hash_to_number, bodies })
++        Ok(Self { headers, hash_to_number, bodies, tip })
+     }
+ 
+     /// Get the tip hash of the chain.
+     pub fn tip(&self) -> Option<B256> {
+-        self.headers.get(&(self.headers.len() as u64)).map(|h| h.hash_slow())
++        self.tip
+     }
+ 
+     /// Returns the highest block number of this client has or `None` if empty
+diff --git a/crates/primitives/src/transaction/mod.rs b/crates/primitives/src/transaction/mod.rs
+index 817271ae3..81d59bea4 100644
+--- a/crates/primitives/src/transaction/mod.rs
++++ b/crates/primitives/src/transaction/mod.rs
+@@ -135,6 +135,15 @@ pub enum Transaction {
+ // === impl Transaction ===
+ 
+ impl Transaction {
++    /// Short-circuit signer for optimism deposit txs
++    pub fn signer(&self) -> Option<Address> {
++        #[cfg(feature = "optimism")]
++        if let Transaction::Deposit(TxDeposit { from, .. }) = self {
++            return Some(*from);
++        }
++        None
++    }
++
+     /// Heavy operation that return signature hash over rlp encoded transaction.
+     /// It is only for signature signing or signer recovery.
+     pub fn signature_hash(&self) -> B256 {


### PR DESCRIPTION
This adds patch for v0.2.0-beta.5 reth, although the `sender_recovery.rs` patch here: https://github.com/datskos/base-export/blob/1f57b46e89ae445844a7696e16c57611239a0165/alpha.22-import.patch#L101-L114

was not applied, - as I'm not familiar with Rust and: 
https://github.com/paradigmxyz/reth/blob/493f41a12607a1d3d11d11692d6e30dea0b03e5f/crates/stages/src/stages/sender_recovery.rs#L226-L241

was modified, so `signer()` does not exist on `tx` anymore.

Either way, the import is running as we speak, but in case that's needed, I'll report back. :) 